### PR TITLE
Add canonical person identifiers to structured data

### DIFF
--- a/src/components/PublicationSchema.js
+++ b/src/components/PublicationSchema.js
@@ -3,6 +3,47 @@ import React from 'react';
 import { Helmet } from 'react-helmet';
 import { useStaticQuery, graphql } from 'gatsby';
 
+const RASHID_ID = 'https://rsdmu.com/#bio';
+const RASHID_URL = 'https://rsdmu.com/';
+const RASHID_SAME_AS = [
+  'https://www.linkedin.com/in/rashid-mushkani',
+  'https://github.com/rsdmu',
+  'https://scholar.google.com/citations?user=PClylNUAAAAJ&hl=en',
+  'https://unesco-studio.umontreal.ca/team/rashid_mushkani.html',
+  'https://orcid.org/0000-0002-3173-8310',
+  'https://amenagement.umontreal.ca/en/recherche/professeurs/fiche/in/in35141/sg/Rashid%20Mushkani/',
+  'https://www.researchgate.net/profile/Rashid-Mushkani-2?ev=hdr_xprf',
+  'https://sp-exchange.ca/podcast/urban-planning-artificial-intelligence-and-inclusive-cities-an-interview-with-rashid-mushkani/',
+  'https://mila.quebec/en/directory/rashid-mushkani',
+];
+
+const RASHID_NAME_VARIANTS = new Set([
+  'Rashid Mushkani',
+  'Rashid A. Mushkani',
+  'Rashid Ahmad Mushkani',
+].map(name => name.toLowerCase()));
+
+const normaliseSiteUrl = (siteUrl) =>
+  siteUrl.endsWith('/') ? siteUrl.slice(0, -1) : siteUrl;
+
+const mapAuthor = (rawName) => {
+  const name = rawName.trim();
+  if (RASHID_NAME_VARIANTS.has(name.toLowerCase())) {
+    return {
+      '@type': 'Person',
+      '@id': RASHID_ID,
+      name,
+      url: RASHID_URL,
+      sameAs: RASHID_SAME_AS,
+    };
+  }
+
+  return {
+    '@type': 'Person',
+    name,
+  };
+};
+
 const PublicationSchema = ({ publication }) => {
   // Query site metadata to get the site URL and title
   const data = useStaticQuery(graphql`
@@ -17,16 +58,16 @@ const PublicationSchema = ({ publication }) => {
   `);
 
   const { siteUrl, title: siteTitle } = data.site.siteMetadata;
+  const baseSiteUrl = normaliseSiteUrl(siteUrl);
 
   // Split authors by comma and trim whitespace
-  const authors = publication.author.split(',').map(name => ({
-    "@type": "Person",
-    "name": name.trim(),
-  }));
+  const authors = publication.author
+    ? publication.author.split(',').map(mapAuthor)
+    : [];
 
   // Construct the absolute URL for the thumbnail image if it exists
-  const imageUrl = publication.thumbnail
-    ? `${siteUrl}${publication.thumbnail}`
+  const imageUrl = publication.thumbnail?.publicURL
+    ? `${baseSiteUrl}${publication.thumbnail.publicURL}`
     : undefined;
 
   const schema = {
@@ -45,7 +86,7 @@ const PublicationSchema = ({ publication }) => {
     },
     "mainEntityOfPage": {
       "@type": "WebPage",
-      "@id": `${siteUrl}/${publication.path}`,
+      "@id": `${baseSiteUrl}/${publication.path}`,
     },
   };
 

--- a/src/components/WorkSchema.js
+++ b/src/components/WorkSchema.js
@@ -3,6 +3,47 @@ import React from 'react';
 import { Helmet } from 'react-helmet';
 import { useStaticQuery, graphql } from 'gatsby';
 
+const RASHID_ID = 'https://rsdmu.com/#bio';
+const RASHID_URL = 'https://rsdmu.com/';
+const RASHID_SAME_AS = [
+  'https://www.linkedin.com/in/rashid-mushkani',
+  'https://github.com/rsdmu',
+  'https://scholar.google.com/citations?user=PClylNUAAAAJ&hl=en',
+  'https://unesco-studio.umontreal.ca/team/rashid_mushkani.html',
+  'https://orcid.org/0000-0002-3173-8310',
+  'https://amenagement.umontreal.ca/en/recherche/professeurs/fiche/in/in35141/sg/Rashid%20Mushkani/',
+  'https://www.researchgate.net/profile/Rashid-Mushkani-2?ev=hdr_xprf',
+  'https://sp-exchange.ca/podcast/urban-planning-artificial-intelligence-and-inclusive-cities-an-interview-with-rashid-mushkani/',
+  'https://mila.quebec/en/directory/rashid-mushkani',
+];
+
+const RASHID_NAME_VARIANTS = new Set([
+  'Rashid Mushkani',
+  'Rashid A. Mushkani',
+  'Rashid Ahmad Mushkani',
+].map(name => name.toLowerCase()));
+
+const normaliseSiteUrl = (siteUrl) =>
+  siteUrl.endsWith('/') ? siteUrl.slice(0, -1) : siteUrl;
+
+const mapAuthor = (rawName) => {
+  const name = rawName.trim();
+  if (RASHID_NAME_VARIANTS.has(name.toLowerCase())) {
+    return {
+      '@type': 'Person',
+      '@id': RASHID_ID,
+      name,
+      url: RASHID_URL,
+      sameAs: RASHID_SAME_AS,
+    };
+  }
+
+  return {
+    '@type': 'Person',
+    name,
+  };
+};
+
 const WorkSchema = ({ work }) => {
   // Query site metadata to get the site URL and title
   const data = useStaticQuery(graphql`
@@ -17,18 +58,16 @@ const WorkSchema = ({ work }) => {
   `);
 
   const { siteUrl, title: siteTitle } = data.site.siteMetadata;
+  const baseSiteUrl = normaliseSiteUrl(siteUrl);
 
   // Split authors by comma and trim whitespace
   const authors = work.author
-    ? work.author.split(',').map(name => ({
-        "@type": "Person",
-        "name": name.trim(),
-      }))
+    ? work.author.split(',').map(mapAuthor)
     : [];
 
   // Construct the absolute URL for the thumbnail image if it exists
-  const imageUrl = work.thumbnail
-    ? `${siteUrl}${work.thumbnail}`
+  const imageUrl = work.thumbnail?.publicURL
+    ? `${baseSiteUrl}${work.thumbnail.publicURL}`
     : undefined;
 
   const schema = {
@@ -38,7 +77,7 @@ const WorkSchema = ({ work }) => {
     "author": authors,
     "datePublished": work.date,
     "description": work.description,
-    "url": `${siteUrl}/${work.path}`,
+    "url": `${baseSiteUrl}/${work.path}`,
     "image": imageUrl,
     "publisher": {
       "@type": "Organization",
@@ -47,7 +86,7 @@ const WorkSchema = ({ work }) => {
     },
     "mainEntityOfPage": {
       "@type": "WebPage",
-      "@id": `${siteUrl}/${work.path}`,
+      "@id": `${baseSiteUrl}/${work.path}`,
     },
   };
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -66,21 +66,27 @@ const IndexPage = ({ data }) => {
 
       {/* Structured Data JSON-LD */}
       <script type="application/ld+json">
-        {`
-        {
+        {JSON.stringify({
           "@context": "https://schema.org",
           "@type": "Person",
+          "@id": "https://rsdmu.com/#bio",
           "name": "Rashid Ahmad Mushkani",
           "image": "https://rsdmu.com/static/88867faf044097371b9619d62c5a5187/cc927/profile-photo.webp",
           "jobTitle": "PhD Candidate at University of Montreal",
           "affiliation": "Mila / University of Montreal",
-          "url": "https://rsdmu.com",
+          "url": "https://rsdmu.com/",
           "sameAs": [
             "https://www.linkedin.com/in/rashid-mushkani",
-            "https://github.com/rsdmu"
+            "https://github.com/rsdmu",
+            "https://scholar.google.com/citations?user=PClylNUAAAAJ&hl=en",
+            "https://unesco-studio.umontreal.ca/team/rashid_mushkani.html",
+            "https://orcid.org/0000-0002-3173-8310",
+            "https://amenagement.umontreal.ca/en/recherche/professeurs/fiche/in/in35141/sg/Rashid%20Mushkani/",
+            "https://www.researchgate.net/profile/Rashid-Mushkani-2?ev=hdr_xprf",
+            "https://sp-exchange.ca/podcast/urban-planning-artificial-intelligence-and-inclusive-cities-an-interview-with-rashid-mushkani/",
+            "https://mila.quebec/en/directory/rashid-mushkani"
           ]
-        }
-        `}
+        })}
       </script>
       
       {/* Hero Section */}


### PR DESCRIPTION
## Summary
- add a canonical `@id` and the latest authoritative profile links to the homepage Person JSON-LD
- attach the canonical Person identifier and profile URLs to works and publications when the author name matches Rashid
- normalize site URL handling when composing structured data asset links

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9a99e9798832ba721bf72b4ee7b5b