### PR TITLE
Add biography metadata to Person JSON-LD

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -74,7 +74,7 @@ const IndexPage = ({ data }) => {
           "image": "https://rsdmu.com/static/88867faf044097371b9619d62c5a5187/cc927/profile-photo.webp",
           "jobTitle": "PhD Candidate at University of Montreal",
           "affiliation": "Mila / University of Montreal",
-          "description": "Rashid Ahmad Mushkani is a PhD candidate and lecturer at the University of Montreal and Mila researching participatory AI for inclusive public spaces and socio-spatial justice.",
+          "description": "Rashid Mushkani is a researcher and lecturer at the University of Montreal and Mila researching participatory AI for inclusive public spaces and socio-spatial justice.",
           "url": "https://rsdmu.com/",
           "knowsAbout": [
             "Participatory urban planning",

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -74,7 +74,37 @@ const IndexPage = ({ data }) => {
           "image": "https://rsdmu.com/static/88867faf044097371b9619d62c5a5187/cc927/profile-photo.webp",
           "jobTitle": "PhD Candidate at University of Montreal",
           "affiliation": "Mila / University of Montreal",
+          "description": "Rashid Ahmad Mushkani is a PhD candidate and lecturer at the University of Montreal and Mila researching participatory AI for inclusive public spaces and socio-spatial justice.",
           "url": "https://rsdmu.com/",
+          "knowsAbout": [
+            "Participatory urban planning",
+            "Inclusive public spaces",
+            "Socio-spatial justice",
+            "Pluralistic AI alignment",
+            "Artificial intelligence ethics",
+            "Spatial justice"
+          ],
+          "knowsLanguage": [
+            "English"
+          ],
+          "hasOccupation": {
+            "@type": "Occupation",
+            "name": "PhD Candidate and Lecturer in Urban Planning and AI",
+            "description": "Advances participatory design and inclusive public space research through AI collaborations at the University of Montreal and Mila.",
+            "startDate": "2022",
+            "employer": [
+              {
+                "@type": "CollegeOrUniversity",
+                "name": "University of Montreal",
+                "sameAs": "https://amenagement.umontreal.ca/en/recherche/doctorantes-et-doctorants/etudiant/in/in35141/sg/Rashid%20Mushkani/"
+              },
+              {
+                "@type": "ResearchOrganization",
+                "name": "Mila - Quebec Artificial Intelligence Institute",
+                "sameAs": "https://mila.quebec/en/directory/rashid-mushkani"
+              }
+            ]
+          },
           "sameAs": [
             "https://www.linkedin.com/in/rashid-mushkani",
             "https://github.com/rsdmu",


### PR DESCRIPTION
## Summary
- add Rashid Mushkani's biography description and expertise to the home page Person JSON-LD block
- expose knowledge domains, languages, and occupation details in the structured data schema

## Testing
- npm run build *(fails: gatsby-plugin-webfonts 403 while downloading fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68e33fa96298832baf8c57d2ee3a47f0