### PR TITLE
Align Person schema with canonical headshot metadata

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -70,8 +70,15 @@ const IndexPage = ({ data }) => {
           "@context": "https://schema.org",
           "@type": "Person",
           "@id": "https://rsdmu.com/#bio",
-          "name": "Rashid Ahmad Mushkani",
-          "image": "https://rsdmu.com/static/88867faf044097371b9619d62c5a5187/cc927/profile-photo.webp",
+          "name": "Rashid Mushkani",
+          "image": {
+            "@type": "ImageObject",
+            "@id": "https://rsdmu.com/#headshot",
+            "url": "https://rsdmu.com/assets/rashid-mushkani-headshot.webp",
+            "width": 1396,
+            "height": 1744,
+            "caption": "Rashid Mushkani smiling outdoors."
+          },
           "jobTitle": "PhD Candidate at University of Montreal",
           "affiliation": "Mila / University of Montreal",
           "url": "https://rsdmu.com/",


### PR DESCRIPTION
## Summary
- update the Person JSON-LD name and caption to the canonical "Rashid Mushkani" form
- point the headshot ImageObject URL to the permanent `/assets/rashid-mushkani-headshot.webp` path

## Testing
- node - <<'NODE'
const fs = require('fs');
const contents = fs.readFileSync('src/pages/index.js', 'utf8');
const match = contents.match(/JSON\.stringify\((\{[\s\S]*?\})\)/);
if (!match) throw new Error('JSON-LD not found');
const obj = eval('(' + match[1] + ')');
console.log(JSON.stringify(obj, null, 2));
NODE

------
https://chatgpt.com/codex/tasks/task_e_68e33fc094ac832ba03defd0235e2056